### PR TITLE
General Makefile QOL improvements & bugfixes

### DIFF
--- a/disasm/Makefile
+++ b/disasm/Makefile
@@ -16,10 +16,10 @@ OUTFILES = -n tetris.sym -m tetris.map
 
 all: tetris.gb
 
-build//titleScreen.2bpp: gfx//2bpp//titleScreen.png
+build/titleScreen.2bpp: gfx/2bpp/titleScreen.png
 	rgbgfx -o $@ $< -x 9
 
-build//menuScreens.2bpp: gfx//2bpp//menuScreens.png
+build/menuScreens.2bpp: gfx/2bpp/menuScreens.png
 	rgbgfx -o $@ $< -x 11
 
 build/%.2bpp: gfx/2bpp/%.png

--- a/disasm/Makefile
+++ b/disasm/Makefile
@@ -44,7 +44,7 @@ tetris.gb: $(GFX_1BPP_OBJS) $(GFX_2BPP_OBJS) $(OBJS) $(RAM_OBJS)
 	rgblink $(OUTFILES) -w -o $@ $(OBJS) $(RAM_OBJS)
 	rgbfix -v -p 255 $@
 
-	md5 $@
+	md5sum $@
 
 clean:
 	rm -f tetris.gb tetris.sym tetris.map build/*


### PR DESCRIPTION
Hello!

I made some changes to the project Makefile, one in particular was causing the project to not assemble. The fix was simple enough to allow the ROM to build, however the 2nd change here is mostly up for debate.

See, I have to assume this project was done using macOS, however the Linux equivalent to the `md5` command would be `md5sum`, which is also installable on macOS via `brew install md5sha1sum` I feel this is the best compromise here to not have unwanted errors during building, despite this step being non-crucial. 

I'm open to suggestions on a better way to handle this, such as detecting the platform this project is being built on and using the appropriate command?

Thanks!