### PR TITLE
update source to support rgbds v0.6+

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 * Former is used for scripts, and `tools/cmp.sh`, and the latter for web visualisations
 
 # Building
-* Install rgbds v0.5.1
+* Install RGBDS v0.6.1
 * Run `make` within the `disasm` directory
 * Run `tools/cmp.sh` to compare built ROM against original ROM
 

--- a/disasm/include/hardware.inc
+++ b/disasm/include/hardware.inc
@@ -28,7 +28,7 @@
     IF !DEF(HARDWARE_INC)
 DEF HARDWARE_INC EQU 1
 
-rev_Check_hardware_inc : MACRO
+MACRO rev_Check_hardware_inc
 ;NOTE: REVISION NUMBER CHANGES MUST BE ADDED
 ;TO SECOND PARAMETER IN FOLLOWING LINE.
     IF  \1 > 2.7 ;PUT REVISION NUMBER HERE
@@ -767,7 +767,7 @@ SCRN_VY_B EQU 32  ; Virtual height of screen in bytes
 ;* Nintendo scrolling logo
 ;* (Code won't work on a real GameBoy)
 ;* (if next lines are altered.)
-NINTENDO_LOGO : MACRO
+MACRO NINTENDO_LOGO
     DB  $CE,$ED,$66,$66,$CC,$0D,$00,$0B,$03,$73,$00,$83,$00,$0C,$00,$0D
     DB  $00,$08,$11,$1F,$88,$89,$00,$0E,$DC,$CC,$6E,$E6,$DD,$DD,$D9,$99
     DB  $BB,$BB,$67,$63,$6E,$0E,$EC,$CC,$DD,$DC,$99,$9F,$BB,$B9,$33,$3E

--- a/disasm/include/hardware.inc
+++ b/disasm/include/hardware.inc
@@ -26,7 +26,7 @@
 ; If all of these are already defined, don't do it again.
 
     IF !DEF(HARDWARE_INC)
-HARDWARE_INC SET 1
+DEF HARDWARE_INC EQU 1
 
 rev_Check_hardware_inc : MACRO
 ;NOTE: REVISION NUMBER CHANGES MUST BE ADDED

--- a/disasm/include/macros.s
+++ b/disasm/include/macros.s
@@ -2,12 +2,12 @@
 ; -- Misc
 ; --
 
-ldbc: macro
+macro ldbc
     ld bc, (\1<<8)|\2
 endm
 
 ; for xor a where 0 can be subbed with a constant
-lda: macro
+macro lda
 ASSERT \1 == $00
     xor a
 endm
@@ -30,31 +30,31 @@ Asharp = 10
 Bnote = 11
 ; Sound data bytes
 ; C2 = 2, C#2 = 4
-PlayNote: macro
+macro PlayNote
     db (\1+1+(\2-2)*12)*2
 endm
-SetParams: macro
+macro SetParams
     db $9d
     dw \1
     db \2
 endm
-UseTempo: macro
+macro UseTempo
     db $a0|\1
 endm
-DisableEnvelope: macro
+macro DisableEnvelope
     db $01
 endm
-NextSection: macro
+macro NextSection
     db $00
 endm
-PlayNoise: macro
+macro PlayNoise
     db \1*5+1
 endm
 
 ; Used in tables containing sound byte addresses
-JumpSection: macro
+macro JumpSection
     dw $ffff, \1
 endm
-EndSong: macro
+macro EndSong
     dw $0000
 endm


### PR DESCRIPTION
Hello once again!

I've updated the source to support RGBDS v0.6+, since some syntax has changed preventing assembling w/o compiling and installing v0.5.1 from source. This will improve usability greatly.

Changes were quite simple. Only thing that was really preventing assembly was the HARDWARE_INC define. The syntax was changed and the old way was not obsoleted, rather removed entirely, so that needed to be changed. Everything else was just macro definitions due to the syntax for that also being changed.

Thanks!